### PR TITLE
Even better fixup to project fixups

### DIFF
--- a/VS Addin/MonoDevelop.MicroFramework/Extensions.cs
+++ b/VS Addin/MonoDevelop.MicroFramework/Extensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using MonoDevelop.Projects.MSBuild;
+
+namespace MonoDevelop.MicroFramework
+{
+		static class Extensions
+		{
+			public static void AddImportIfMissing (this MSBuildProject project, string name, string condition = null)
+			{
+				var existing = project.GetImport (name, condition);
+				if (existing == null)
+					project.AddNewImport (name, condition);
+			}
+
+			public static void RemoveProperty (this MSBuildProject project, string name)
+			{
+				foreach (var group in project.PropertyGroups)
+					group.RemoveProperty (name);
+			}
+        }
+ }

--- a/VS Addin/MonoDevelop.MicroFramework/MonoDevelop.MicroFramework.csproj
+++ b/VS Addin/MonoDevelop.MicroFramework/MonoDevelop.MicroFramework.csproj
@@ -88,6 +88,7 @@
     <Compile Include="FrameworkSetup.cs" />
     <Compile Include="Properties\AddinInfo.cs" />
     <Compile Include="MicroFrameworkRuntimeFactory.cs" />
+    <Compile Include="Extensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templates\MicroFrameworkLibraryProject.xpt.xml">


### PR DESCRIPTION
These need to happen on the unevaluated `MSBuildProject`.
No idea how it ever worked before (e.g. in 876cc98 or even before that),
but it seems to work now. Hooray!

Should fix https://github.com/WildernessLabs/NetMF_MonoDevelop_VS_Mac_Addin/issues/12 but a little extra testing wouldn't hurt 😁